### PR TITLE
Better hist handling

### DIFF
--- a/analysis/wwz/get_wwz_counts.py
+++ b/analysis/wwz/get_wwz_counts.py
@@ -19,7 +19,7 @@ def get_counts(histos_dict):
     # Get object multiplicity counts (nleps, njets, nbtags)
     ojb_lst = ["nleps","njets","nbtagsl"]
     for obj in ojb_lst:
-        nobjs_hist = histos_dict[obj]["all_events"][wwz_sync_sample].values(flow=True)[0]
+        nobjs_hist = histos_dict[obj][{"category":"all_events","process":wwz_sync_sample}].values(flow=True)
         tot_objs = 0
         for i,v in enumerate(nobjs_hist):
             tot_objs = tot_objs + (i-1.)*v # Have to adjust for the fact that first bin is underflow, second bin is 0 objects
@@ -28,8 +28,8 @@ def get_counts(histos_dict):
 
     # Look at the event counts in one histo (e.g. njets)
     dense_axis = "njets"
-    for cat_name in histos_dict[dense_axis].keys():
-        val = sum(histos_dict[dense_axis][cat_name][wwz_sync_sample].values()[0])
+    for cat_name in histos_dict[dense_axis].axes["category"]:
+        val = sum(histos_dict[dense_axis][{"category":cat_name,"process":wwz_sync_sample}].values(flow=True))
         out_dict[wwz_sync_sample][cat_name] = (val,None) # Save err as None
         #print(dense_axis,cat_name,val)
 
@@ -47,6 +47,8 @@ def main():
 
     # Get the counts from the input hiso
     histo_dict = pickle.load(gzip.open(args.pkl_file_path))
+
+
     counts_dict = get_counts(histo_dict)
 
     # Print the counts

--- a/analysis/wwz/get_wwz_counts.py
+++ b/analysis/wwz/get_wwz_counts.py
@@ -17,7 +17,7 @@ def get_counts(histos_dict):
     out_dict[wwz_sync_sample] = {}
 
     # Get object multiplicity counts (nleps, njets, nbtags)
-    ojb_lst = ["nleps","njets","nbtagsl"]
+    ojb_lst = ["nleps_counts","njets_counts","nbtagsl_counts"]
     for obj in ojb_lst:
         nobjs_hist = histos_dict[obj][{"category":"all_events","process":wwz_sync_sample}].values(flow=True)
         tot_objs = 0
@@ -27,11 +27,17 @@ def get_counts(histos_dict):
         #print("\ntotobj",obj,tot_objs)
 
     # Look at the event counts in one histo (e.g. njets)
+    dense_axis = "njets_counts"
+    for cat_name in histos_dict[dense_axis].axes["category"]:
+        val = sum(histos_dict[dense_axis][{"category":cat_name,"process":wwz_sync_sample}].values(flow=True))
+        out_dict[wwz_sync_sample][cat_name+"_counts"] = (val,None) # Save err as None
+
+    # Look at the yields in one histo (e.g. njets)
     dense_axis = "njets"
     for cat_name in histos_dict[dense_axis].axes["category"]:
         val = sum(histos_dict[dense_axis][{"category":cat_name,"process":wwz_sync_sample}].values(flow=True))
         out_dict[wwz_sync_sample][cat_name] = (val,None) # Save err as None
-        #print(dense_axis,cat_name,val)
+
 
     return out_dict
 

--- a/analysis/wwz/ref_for_ci/counts_wwz_ref.json
+++ b/analysis/wwz/ref_for_ci/counts_wwz_ref.json
@@ -1,51 +1,87 @@
 {
     "UL17_WWZJetsTo4L2Nu": {
-        "nleps": [
+        "nleps_counts": [
             158395.0,
             null
         ],
-        "njets": [
+        "njets_counts": [
             94133.0,
             null
         ],
-        "nbtagsl": [
+        "nbtagsl_counts": [
             19064.0,
             null
         ],
-        "4l_wwz_sf_A": [
+        "4l_wwz_sf_A_counts": [
             929.0,
             null
         ],
-        "4l_wwz_sf_B": [
+        "4l_wwz_sf_B_counts": [
             713.0,
             null
         ],
-        "4l_wwz_sf_C": [
+        "4l_wwz_sf_C_counts": [
             207.0,
             null
         ],
-        "4l_wwz_of_1": [
+        "4l_wwz_of_1_counts": [
             253.0,
             null
         ],
-        "4l_wwz_of_2": [
+        "4l_wwz_of_2_counts": [
             314.0,
             null
         ],
-        "4l_wwz_of_3": [
+        "4l_wwz_of_3_counts": [
             631.0,
             null
         ],
-        "4l_wwz_of_4": [
+        "4l_wwz_of_4_counts": [
             2033.0,
             null
         ],
-        "all_events": [
+        "all_events_counts": [
             54868.0,
             null
         ],
-        "4l_presel": [
+        "4l_presel_counts": [
             9865.0,
+            null
+        ],
+        "4l_wwz_sf_A": [
+            0.7075932520092465,
+            null
+        ],
+        "4l_wwz_sf_B": [
+            0.5534297283156775,
+            null
+        ],
+        "4l_wwz_sf_C": [
+            0.15329743648180738,
+            null
+        ],
+        "4l_wwz_of_1": [
+            0.19486962264636531,
+            null
+        ],
+        "4l_wwz_of_2": [
+            0.25809398910496384,
+            null
+        ],
+        "4l_wwz_of_3": [
+            0.49626797233941033,
+            null
+        ],
+        "4l_wwz_of_4": [
+            1.6135204755119048,
+            null
+        ],
+        "all_events": [
+            42.997765715117566,
+            null
+        ],
+        "4l_presel": [
+            7.726364016125444,
             null
         ]
     }

--- a/analysis/wwz/wwz4l.py
+++ b/analysis/wwz/wwz4l.py
@@ -31,23 +31,26 @@ class AnalysisProcessor(processor.ProcessorABC):
             "njets"   :
                 hist.Hist(
                     hist.axis.StrCategory([], growth=True, name="process", label="process"),
+                    hist.axis.StrCategory([], growth=True, name="category", label="category"),
                     axis.Regular(20, 0, 20, name="njets",   label="Jet multiplicity"),
-                    storage="weight",
-                    name="Counts"
+                    storage="weight", # Keeps track of sumw2
+                    name="Counts",
                 ),
             "nleps"   :
                 hist.Hist(
                     hist.axis.StrCategory([], growth=True, name="process", label="process"),
+                    hist.axis.StrCategory([], growth=True, name="category", label="category"),
                     axis.Regular(20, 0, 20, name="nleps",   label="Lep multiplicity"),
-                    storage="weight",
-                    name="Counts"
+                    storage="weight", # Keeps track of sumw2
+                    name="Counts",
                 ),
             "nbtagsl"   :
                 hist.Hist(
                     hist.axis.StrCategory([], growth=True, name="process", label="process"),
+                    hist.axis.StrCategory([], growth=True, name="category", label="category"),
                     axis.Regular(20, 0, 20, name="nbtagsl",   label="Loose btag multiplicity"),
-                    storage="weight",
-                    name="Counts"
+                    storage="weight", # Keeps track of sumw2
+                    name="Counts",
                 ),
         }
 
@@ -335,14 +338,6 @@ class AnalysisProcessor(processor.ProcessorABC):
 
             ######### Store boolean masks with PackedSelection ##########
 
-            #hout = self.accumulator.identity()
-            dense_hists_dict = self._dense_hists_dict
-
-            hout = {
-                "njets" : {},
-                "nleps" : {},
-                "nbtagsl" : {},
-            }
 
             selections = PackedSelection(dtype='uint64')
 
@@ -371,7 +366,9 @@ class AnalysisProcessor(processor.ProcessorABC):
 
             ######### Fill histos #########
 
-            dense_axes_dict = {
+            hout = self._dense_hists_dict
+
+            dense_variables_dict = {
                 #"met" : met.pt,
                 "nleps" : nleps,
                 "njets" : njets,
@@ -382,14 +379,11 @@ class AnalysisProcessor(processor.ProcessorABC):
             weights = events.nom
 
             # Loop over the hists we want to fill
-            for dense_axis_name, dense_axis_vals in dense_axes_dict.items():
+            for dense_axis_name, dense_axis_vals in dense_variables_dict.items():
                 #print("\ndense_axis_name,vals",dense_axis_name)
                 #print("dense_axis_name,vals",dense_axis_vals)
 
                 for sr_cat in sr_cat_dict["lep_chan_lst"]:
-
-                    hout[dense_axis_name][sr_cat] = {}
-                    hout[dense_axis_name][sr_cat][histAxisName] = copy.deepcopy(dense_hists_dict[dense_axis_name])
 
                     # Make the cuts mask
                     cuts_lst = [sr_cat]
@@ -400,9 +394,10 @@ class AnalysisProcessor(processor.ProcessorABC):
                         dense_axis_name : dense_axis_vals[all_cuts_mask],
                         "weight"        : weights[all_cuts_mask],
                         "process"       : histAxisName,
+                        "category"      : sr_cat,
                         #"systematic"    : "nominal",
                     }
-                    hout[dense_axis_name][sr_cat][histAxisName].fill(**axes_fill_info_dict)
+                    hout[dense_axis_name].fill(**axes_fill_info_dict)
 
         return hout
 

--- a/analysis/wwz/wwz4l.py
+++ b/analysis/wwz/wwz4l.py
@@ -383,6 +383,7 @@ class AnalysisProcessor(processor.ProcessorABC):
 
                     # Make the cuts mask
                     cuts_lst = [sr_cat]
+                    if isData: cuts_lst.append("is_good_lumi") # Apply golden json requirements if this is data
                     all_cuts_mask = selections.all(*cuts_lst)
 
                     # Fill the histos

--- a/analysis/wwz/wwz4l.py
+++ b/analysis/wwz/wwz4l.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-import copy
 import coffea
 import numpy as np
 import awkward as ak
@@ -26,42 +25,24 @@ class AnalysisProcessor(processor.ProcessorABC):
         self._wc_names_lst = wc_names_lst
         self._dtype = dtype
 
-        # Create the histograms
-        self._dense_hists_dict = {
-            "njets"   :
-                hist.Hist(
-                    hist.axis.StrCategory([], growth=True, name="process", label="process"),
-                    hist.axis.StrCategory([], growth=True, name="category", label="category"),
-                    axis.Regular(20, 0, 20, name="njets",   label="Jet multiplicity"),
-                    storage="weight", # Keeps track of sumw2
-                    name="Counts",
-                ),
-            "nleps"   :
-                hist.Hist(
-                    hist.axis.StrCategory([], growth=True, name="process", label="process"),
-                    hist.axis.StrCategory([], growth=True, name="category", label="category"),
-                    axis.Regular(20, 0, 20, name="nleps",   label="Lep multiplicity"),
-                    storage="weight", # Keeps track of sumw2
-                    name="Counts",
-                ),
-            "nbtagsl"   :
-                hist.Hist(
-                    hist.axis.StrCategory([], growth=True, name="process", label="process"),
-                    hist.axis.StrCategory([], growth=True, name="category", label="category"),
-                    axis.Regular(20, 0, 20, name="nbtagsl",   label="Loose btag multiplicity"),
-                    storage="weight", # Keeps track of sumw2
-                    name="Counts",
-                ),
+        # Create the dense axes for the histograms
+        self._dense_axes_dict = {
+            "njets"   : axis.Regular(20, 0, 20, name="njets",   label="Jet multiplicity"),
+            "nleps"   : axis.Regular(20, 0, 20, name="nleps",   label="Lep multiplicity"),
+            "nbtagsl" : axis.Regular(20, 0, 20, name="nbtagsl", label="Loose btag multiplicity"),
+            "njets_counts"   : axis.Regular(20, 0, 20, name="njets_counts",   label="Jet multiplicity counts"),
+            "nleps_counts"   : axis.Regular(20, 0, 20, name="nleps_counts",   label="Lep multiplicity counts"),
+            "nbtagsl_counts" : axis.Regular(20, 0, 20, name="nbtagsl_counts", label="Loose btag multiplicity counts"),
         }
 
         # Set the list of hists to fill
         if hist_lst is None:
             # If the hist list is none, assume we want to fill all hists
-            self._hist_lst = list(self._dense_hists_dict.keys())
+            self._hist_lst = list(self._dense_axes_dict.keys())
         else:
             # Otherwise, just fill the specified subset of hists
             for hist_to_include in hist_lst:
-                if hist_to_include not in self._dense_hists_dict.keys():
+                if hist_to_include not in self._dense_axes_dict.keys():
                     raise Exception(f"Error: Cannot specify hist \"{hist_to_include}\", it is not defined in the processor.")
             self._hist_lst = hist_lst # Which hists to fill
 
@@ -366,23 +347,38 @@ class AnalysisProcessor(processor.ProcessorABC):
 
             ######### Fill histos #########
 
-            hout = self._dense_hists_dict
+            hout = {}
 
             dense_variables_dict = {
                 #"met" : met.pt,
                 "nleps" : nleps,
                 "njets" : njets,
                 "nbtagsl" : nbtagsl,
+                "nleps_counts" : nleps,
+                "njets_counts" : njets,
+                "nbtagsl_counts" : nbtagsl,
             }
 
-            weights = weights_obj_base.partial_weight(include=["norm"])
-            weights = events.nom
 
             # Loop over the hists we want to fill
             for dense_axis_name, dense_axis_vals in dense_variables_dict.items():
-                #print("\ndense_axis_name,vals",dense_axis_name)
-                #print("dense_axis_name,vals",dense_axis_vals)
+                print("\ndense_axis_name,vals",dense_axis_name)
+                print("dense_axis_name,vals",dense_axis_vals)
 
+                # Create the hist for this dense axis variable
+                hout[dense_axis_name] = hist.Hist(
+                    hist.axis.StrCategory([], growth=True, name="process", label="process"),
+                    hist.axis.StrCategory([], growth=True, name="category", label="category"),
+                    self._dense_axes_dict[dense_axis_name],
+                    storage="weight", # Keeps track of sumw2
+                    name="Counts",
+                )
+
+                # Decide if we are filling this hist with weight or raw event counts
+                if dense_axis_name.endswith("_counts"): weights = events.nom
+                else: weights = weights_obj_base.partial_weight(include=["norm"])
+
+                # Loop over categories
                 for sr_cat in sr_cat_dict["lep_chan_lst"]:
 
                     # Make the cuts mask

--- a/analysis/wwz/wwz4l.py
+++ b/analysis/wwz/wwz4l.py
@@ -362,8 +362,8 @@ class AnalysisProcessor(processor.ProcessorABC):
 
             # Loop over the hists we want to fill
             for dense_axis_name, dense_axis_vals in dense_variables_dict.items():
-                print("\ndense_axis_name,vals",dense_axis_name)
-                print("dense_axis_name,vals",dense_axis_vals)
+                #print("\ndense_axis_name,vals",dense_axis_name)
+                #print("dense_axis_name,vals",dense_axis_vals)
 
                 # Create the hist for this dense axis variable
                 hout[dense_axis_name] = hist.Hist(


### PR DESCRIPTION
This PR updates the way we declare the hist objects in the processor to make use of `hist.axis.StrCategory` instead of creating the nested dictionaries ourselves.

The PR also updates the histograms to be filled with the normalized weight (instead of just raw MC counts), and adds a few dedicated histograms for the raw MC counts (as these are still useful for validation and CI purposes). 